### PR TITLE
Disable 90% of startup checks

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -41,7 +41,7 @@ module Sidekiq
       include Util
 
       INITIAL_WAIT = 10
-      FRACTION_TO_RUN = 0.1
+      FRACTION_TO_RUN = 0.0
 
       def initialize
         @enq = (Sidekiq.options[:scheduled_enq] || Sidekiq::Scheduled::Enq).new

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -41,6 +41,7 @@ module Sidekiq
       include Util
 
       INITIAL_WAIT = 10
+      FRACTION_TO_RUN = 0.1
 
       def initialize
         @enq = (Sidekiq.options[:scheduled_enq] || Sidekiq::Scheduled::Enq).new
@@ -61,14 +62,16 @@ module Sidekiq
       end
 
       def start
-        @thread ||= safe_thread("scheduler") do
-          initial_wait
+        if rand() < FRACTION_TO_RUN
+          @thread ||= safe_thread("scheduler") do
+            initial_wait
 
-          while !@done
-            enqueue
-            wait
+            while !@done
+              enqueue
+              wait
+            end
+            Sidekiq.logger.info("Scheduler exiting...")
           end
-          Sidekiq.logger.info("Scheduler exiting...")
         end
       end
 

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -41,7 +41,7 @@ module Sidekiq
       include Util
 
       INITIAL_WAIT = 10
-      FRACTION_TO_RUN = 0.0
+      FRACTION_TO_RUN = 1.0
 
       def initialize
         @enq = (Sidekiq.options[:scheduled_enq] || Sidekiq::Scheduled::Enq).new


### PR DESCRIPTION
ref: https://app.asana.com/0/1198103229139841/1200127065515039

Restarting sidekiq in production currently leads to a huge CPU
spike on redis as hundreds of sidekiq processes simultaneously
spawn and look for jobs to schedule. This is technically all
redundant after the first process, however, it is risky to rely
only on one process (what if the process crashes or the server
goes down).

The suggested temporary patch (implemented in this commit)
randomizes which processes will start enqueuing jobs on startup,
allowing only 10% of calls to proceed. This should reduce the load
load on redis for now for very minimal work, but long-term we
should look at not having to rely on custom forks of sidekiq and
sidekiq-cron to do our scheduling.

This is a WIP PR, currently testing the behavior which is why there
are two extra commits that set FRACTION_TO_RUN to 0 and 1.
These two commits are intended to be removed before merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/sidekiq/2)
<!-- Reviewable:end -->
