### PR TITLE
feat: disable sidekiq startup "enqueues" on 90% of processes

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -61,14 +61,16 @@ module Sidekiq
       end
 
       def start
-        @thread ||= safe_thread("scheduler") do
-          initial_wait
+        if ENV['SIDEKIQ_STARTUP_CHECKS'] != '0'
+          @thread ||= safe_thread("scheduler") do
+            initial_wait
 
-          while !@done
-            enqueue
-            wait
+            while !@done
+              enqueue
+              wait
+            end
+            Sidekiq.logger.info("Scheduler exiting...")
           end
-          Sidekiq.logger.info("Scheduler exiting...")
         end
       end
 


### PR DESCRIPTION
ref: https://app.asana.com/0/1198103229139841/1200127065515039

Restarting sidekiq in production currently leads to a huge CPU
spike on redis as hundreds of sidekiq processes simultaneously
spawn and look for jobs to schedule. This is technically all
redundant after the first process, however, it is risky to rely
only on one process (what if the process crashes or the server
goes down).

The suggested temporary patch was to randomize which processes
start enqueuing jobs on startup, allowing only 10% of calls to
proceed. That reduces our immediate control over the number of
processes though, so this commit instead implements an
environment variable check to turn off startup checks on a per-
host basis. This should reduce the load on redis for now for
minimal work.

Supercedes https://github.com/OneSignal/sidekiq/pull/2, please see
the old PR for the discussion behind the change in method from RNG
to env-var.
